### PR TITLE
Add support for php-fpm on Apache.

### DIFF
--- a/KEYS.txt
+++ b/KEYS.txt
@@ -45,6 +45,8 @@ TODO: Find a good way to expose database options as command line arguments where
   - 'server.disable_site_command' - The command to run to disable a site on the server (e.g. `a2dissite sitename` on ubutnu.
   - 'server.enable_site_command' - The command to run to enable a site on the server (e.g. `a2ensite sitename` on ubutnu.
   - 'server.port' - The port to listen on for this virtualhost.
+  - 'server.sapi' - The supported sapi (apache supports fpm and mod_php).
+  - 'server.fpm_url' - The host and port to proxy requests to if the `server.sapi` key is set to `fpm`.
   - 'server.restart_command' - The command to run to reload configuration (e.g. `service apache2 restart`).
   - 'server.user' - The user that the webserver runs as (e.g. `apache2` runs as `www-data` on Ubuntu).
   - 'settings_file.path' - The path to the site's settings.php file.

--- a/assets/apache.drupal.vhost.fpm.tpl.php
+++ b/assets/apache.drupal.vhost.fpm.tpl.php
@@ -1,7 +1,8 @@
-<Directory /var/www/html/<?php print $site_name; ?>/webroot/>
+<Directory <?php print $docroot; ?> >
   Options -Indexes
   Options +FollowSymLinks
   AllowOverride All
+  Require all granted
 
   # Not a part of Drupal's stock .htaccess but added as a measure of security.
   <FilesMatch "(^LICENSE|CHANGELOG|MAINTAINERS|INSTALL|UPGRADE|API|README).*\.txt$">
@@ -16,9 +17,12 @@
     Allow from 127.0.0.1
   </Files>
 </Directory>
-<VirtualHost *:80>
+<VirtualHost *:<?php print $port; ?>>
   ServerName <?php print $hostname . PHP_EOL; ?>
-  DocumentRoot /var/www/html/<?php print $site_name; ?>/webroot
+  DocumentRoot <?php print $docroot . PHP_EOL; ?>
+  <FilesMatch \.php$>
+    SetHandler proxy:fcgi://<?php print $fpm_url . PHP_EOL; ?>
+  </FilesMatch>
   LogLevel warn
   ServerSignature Off
 </VirtualHost>

--- a/assets/apache.drupal.vhost.mod_php.tpl.php
+++ b/assets/apache.drupal.vhost.mod_php.tpl.php
@@ -2,6 +2,7 @@
   Options -Indexes
   Options +FollowSymLinks
   AllowOverride All
+  Require all granted
 
   # Not a part of Drupal's stock .htaccess but added as a measure of security.
   <FilesMatch "(^LICENSE|CHANGELOG|MAINTAINERS|INSTALL|UPGRADE|API|README).*\.txt$">


### PR DESCRIPTION
This adds support for a new directive for the `server.sapi`
allowing you to specify fpm and mod_php (defaulting to mod_php
for now for backward compatibility, future auto-detection would
be nice). If you set `server.sapi` to `fpm` you can then also
use the new `server.fpm_url` to connect to the host and port
appropriate to your fpm instance.